### PR TITLE
Remove the Dockerfile CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM mhart/alpine-node:9.11.1
-WORKDIR /src
-COPY package.json ./
-RUN yarn
-COPY . ./
-RUN yarn test


### PR DESCRIPTION
This is no longer needed as Github Actions provides a better
facility.